### PR TITLE
ISSUE-9: Use static dateformat since qLocaleInfo is undefined

### DIFF
--- a/DateRangePicker.js
+++ b/DateRangePicker.js
@@ -181,7 +181,7 @@ define(["qlik", "jquery", "./lib/moment.min", "./CalendarSettings", "css!./css/s
 
                 function SelectRange(start, end) {
                     qlik.currApp().getAppLayout().then(function (x) {
-                        var DateFormat = layout.qListObject.qDimensionInfo.qNumFormat.qFmt || x.qLocaleInfo.qDateFmt;
+                        var DateFormat = "YYYY-MM-DD";
 
                         self.backendApi.search(">=" + start.format(DateFormat) + "<=" + end.format(DateFormat))
                             .then(


### PR DESCRIPTION
See [issue 9](https://github.com/NOD507/SenseDateRangePicker/issues/9).

Use a static date format for submitting the date range to the backend API, since qLocaleInfo is undefined.