### PR TITLE
Added Few new options (details are below)

### DIFF
--- a/CalendarSettings.js
+++ b/CalendarSettings.js
@@ -95,45 +95,415 @@ define([], function() {
 								label: "Default Text",
                                 expression: "optional",
 								defaultValue: "Select date range"
-							},
-                            Today:{
-                                type: "string",  
-                                ref: "props.today",
-								label: "Today",
-								defaultValue: "Today",
-                                expression: "optional"
                             },
-                            Yesterday:{
-                                type: "string",  
-                                ref: "props.yesterday",
-								label: "Yesterday",
-								defaultValue: "Yesterday",
-                                expression: "optional"
+                            Ranges:{
+                                label: "Ranges",
+                                component: "expandable-items",
+                                items:{
+                                    Today:{
+                                        type:"items",
+                                        label: "Today",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableToday",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.today",
+                                                label: "Label",
+                                                defaultValue: "Today",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    Yesterday:{
+                                        type:"items",
+                                        label: "Yesterday",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableYesterday",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.yesterday",
+                                                label: "Yesterday",
+                                                defaultValue: "Yesterday",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastXDays:{
+                                        type:"items",
+                                        label: "Last X Days",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastXDays",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastXDays",
+                                                label: "Last $ days",
+                                                defaultValue: "Last $ days",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    ThisMonth:{
+                                        type:"items",
+                                        label: "This Month",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableThisMonth",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.thisMonth",
+                                                label: "This Month",
+                                                defaultValue: "This Month",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastMonth:{
+                                        type:"items",
+                                        label: "Last Month",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastMonth",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastMonth",
+                                                label: "Last Month",
+                                                defaultValue: "Last Month",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    CurrentQuarter:{
+                                        type:"items",
+                                        label: "Current Quarter",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableCurrentQuarter",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.currentQuarter",
+                                                label: "Current Quarter",
+                                                defaultValue: "Current Quarter",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastQuarter:{
+                                        type:"items",
+                                        label: "Last Quarter",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastQuarter",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastQuarter",
+                                                label: "Last Quarter",
+                                                defaultValue: "Last Quarter",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    CurrentYear:{
+                                        type:"items",
+                                        label: "Current Year",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableCurrentYear",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.currentYear",
+                                                label: "Current Year",
+                                                defaultValue: "Current Year",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastYear:{
+                                        type:"items",
+                                        label: "Last Year",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastYear",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastYear",
+                                                label: "Last Year",
+                                                defaultValue: "Last Year",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    QuarterToDate:{
+                                        type:"items",
+                                        label: "Quarter To Date",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableQuarterToDate",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.quarterToDate",
+                                                label: "Quarter To Date",
+                                                defaultValue: "Quarter To Date",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    YearToDate:{
+                                        type:"items",
+                                        label: "Year To Date",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableYearToDate",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.yearToDate",
+                                                label: "Year To Date",
+                                                defaultValue: "Year To Date",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    Rolling12Months:{
+                                        type:"items",
+                                        label: "Rolling 12 Months",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableRolling12Months",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.rolling12Months",
+                                                label: "Rolling 12 Months",
+                                                defaultValue: "Rolling 12 Months",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    Rolling12MonthsFull:{
+                                        type:"items",
+                                        label: "Rolling 12 Months Full",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableRolling12MonthsFull",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.rolling12MonthsFull",
+                                                label: "Rolling 12 Months Full",
+                                                defaultValue: "Rolling 12 Months Full",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    }
+                                },
                             },
-                            LastDays:{
-                                type: "string",  
-                                ref: "props.lastXDays",
-								label: "Last $ days",
-								defaultValue: "Last $ days",
-                                expression: "optional"
-                            },
-                            ThisMonth:{
-                                type: "string",  
-                                ref: "props.thisMonth",
-								label: "This Month",
-								defaultValue: "This Month",
-                                expression: "optional"
-                            },
-                            LastMonth:{
-                                type: "string",  
-                                ref: "props.lastMonth",
-								label: "Last Month",
-								defaultValue: "Last Month",
-                                expression: "optional"
-                            }
-                            
 					}
-				}
+				},
+				header2: {
+					type: "items",
+					label: "Miscellaneous",
+					items: {
+                            DateSelectionStatus: {
+		                        type: "boolean",
+                                component: "switch",
+                                label: "Show Selections Details",
+                                ref: "props.isSelectionDetailsEnabled",
+                                options: [{
+                                    value: true,
+                                    translation: "properties.on"
+                                }, {
+                                    value: false,
+                                    translation: "properties.off"
+                                }],
+                                defaultValue: true
+                            },
+                            ShowInvalidRanges: {
+		                        type: "boolean",
+                                component: "switch",
+                                label: "Show Invalid Ranges and Grey them out",
+                                ref: "props.showInvalidRanges",
+                                options: [{
+                                    value: true,
+                                    translation: "properties.on"
+                                }, {
+                                    value: false,
+                                    translation: "properties.off"
+                                }],
+                                defaultValue: false
+                            },
+                            DisableDateInputFields: {
+		                        type: "boolean",
+                                component: "switch",
+                                label: "Disable date input fields",
+                                ref: "props.disableDateInputFields",
+                                options: [{
+                                    value: true,
+                                    translation: "properties.on"
+                                }, {
+                                    value: false,
+                                    translation: "properties.off"
+                                }],
+                                defaultValue: false
+                            },
+                        
+                    }
+                }
 			}
 		};
 		return 	CalendarSettings;

--- a/CalendarSettings.spa.js
+++ b/CalendarSettings.spa.js
@@ -73,39 +73,415 @@ define([], function() {
 								label: "Default Text",
 								defaultValue: "Seleccione un rango"
 							},
-                            Today:{
-                                type: "string",  
-                                ref: "props.today",
-								label: "Today",
-								defaultValue: "Hoy"
-                            },
-                            Yesterday:{
-                                type: "string",  
-                                ref: "props.yesterday",
-								label: "Yesterday",
-								defaultValue: "Ayer"
-                            },
-                            LastDays:{
-                                type: "string",  
-                                ref: "props.lastXDays",
-								label: "Last $ days",
-								defaultValue: "Últimos $ días"
-                            },
-                            ThisMonth:{
-                                type: "string",  
-                                ref: "props.thisMonth",
-								label: "This Month",
-								defaultValue: "Mes Actual"
-                            },
-                            LastMonth:{
-                                type: "string",  
-                                ref: "props.lastMonth",
-								label: "Last Month",
-								defaultValue: "Mes Anterior"
+                            Ranges:{
+                                label: "Ranges",
+                                component: "expandable-items",
+                                items:{
+                                    Today:{
+                                        type:"items",
+                                        label: "Today",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableToday",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.today",
+                                                label: "Label",
+                                                defaultValue: "Hoy",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    Yesterday:{
+                                        type:"items",
+                                        label: "Yesterday",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableYesterday",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.yesterday",
+                                                label: "Yesterday",
+                                                defaultValue: "Ayer",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastXDays:{
+                                        type:"items",
+                                        label: "Last X Days",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastXDays",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastXDays",
+                                                label: "Last $ days",
+                                                defaultValue: "Últimos $ días",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    ThisMonth:{
+                                        type:"items",
+                                        label: "This Month",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableThisMonth",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.thisMonth",
+                                                label: "This Month",
+                                                defaultValue: "Mes Actual",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastMonth:{
+                                        type:"items",
+                                        label: "Last Month",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastMonth",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastMonth",
+                                                label: "Last Month",
+                                                defaultValue: "Mes Anterior",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    CurrentQuarter:{
+                                        type:"items",
+                                        label: "Current Quarter",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableCurrentQuarter",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.currentQuarter",
+                                                label: "Current Quarter",
+                                                defaultValue: "Trimestre Actual",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastQuarter:{
+                                        type:"items",
+                                        label: "Last Quarter",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastQuarter",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastQuarter",
+                                                label: "Last Quarter",
+                                                defaultValue: "Trimestre Anterior",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    CurrentYear:{
+                                        type:"items",
+                                        label: "Current Year",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableCurrentYear",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.currentYear",
+                                                label: "Current Year",
+                                                defaultValue: "Año Actual",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    LastYear:{
+                                        type:"items",
+                                        label: "Last Year",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableLastYear",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.lastYear",
+                                                label: "Last Year",
+                                                defaultValue: "Año Anterior",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    QuarterToDate:{
+                                        type:"items",
+                                        label: "Quarter To Date",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableQuarterToDate",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.quarterToDate",
+                                                label: "Quarter To Date",
+                                                defaultValue: "Trimestre Hasta Ahora",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    YearToDate:{
+                                        type:"items",
+                                        label: "Year To Date",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableYearToDate",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.yearToDate",
+                                                label: "Year To Date",
+                                                defaultValue: "Año Hasta Ahora",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    Rolling12Months:{
+                                        type:"items",
+                                        label: "Rolling 12 Months",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableRolling12Months",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.rolling12Months",
+                                                label: "Rolling 12 Months",
+                                                defaultValue: "Rodando 12 Meses",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    },
+                                    Rolling12MonthsFull:{
+                                        type:"items",
+                                        label: "Rolling 12 Months Full",
+                                        items: {
+                                            EnableRange: {
+                                                type: "boolean",
+                                                component: "switch",
+                                                label: "Show",
+                                                ref: "props.enableRolling12MonthsFull",
+                                                options: [{
+                                                    value: true,
+                                                    translation: "properties.on"
+                                                }, {
+                                                    value: false,
+                                                    translation: "properties.off"
+                                                }],
+                                                defaultValue: true
+                                            },
+                                            Text: {
+                                                type: "string",  
+                                                ref: "props.rolling12MonthsFull",
+                                                label: "Rolling 12 Months Full",
+                                                defaultValue: "Rodando 12 Meses Completos",
+                                                expression: "optional"
+                                            }
+                                        }
+                                    }
+                                },
                             }
-                            
+                                                        
 					}
-				}
+				},
+				header2: {
+					type: "items",
+					label: "Miscellaneous",
+					items: {
+                            DateSelectionStatus:{
+		                        type: "boolean",
+                                component: "switch",
+                                label: "Mostrar detalles de selección",
+                                ref: "props.isSelectionDetailsEnabled",
+                                options: [{
+                                    value: true,
+                                    translation: "properties.on"
+                                }, {
+                                    value: false,
+                                    translation: "properties.off"
+                                }],
+                                defaultValue: true
+                            },
+                            ShowInvalidRanges: {
+		                        type: "boolean",
+                                component: "switch",
+                                label: "Mostrar rangos inválidos y gritarlos",
+                                ref: "props.showInvalidRanges",
+                                options: [{
+                                    value: true,
+                                    translation: "properties.on"
+                                }, {
+                                    value: false,
+                                    translation: "properties.off"
+                                }],
+                                defaultValue: false
+                            },
+                            DisableDateInputFields: {
+		                        type: "boolean",
+                                component: "switch",
+                                label: "Desactivar campos de fecha de entrada",
+                                ref: "props.disableDateInputFields",
+                                options: [{
+                                    value: true,
+                                    translation: "properties.on"
+                                }, {
+                                    value: false,
+                                    translation: "properties.off"
+                                }],
+                                defaultValue: false
+                            },
+                        
+                    }
+                }
 			}
 		};
 		return 	CalendarSettings;

--- a/DateRangePicker.js
+++ b/DateRangePicker.js
@@ -136,9 +136,13 @@ define(["qlik", "jquery", "./lib/moment.min", "./CalendarSettings", "css!./css/s
                         "format": layout.props.format,
                         "separator": layout.props.separator
                     },
+                    "rangeOptions": {
+                        "showInvalidRanges": layout.props.showInvalidRanges
+                    },
+                    "disableDateInputFields": layout.props.disableDateInputFields,
                     "parentEl": "#grid",
                     "autoUpdateInput": false,
-                    "autoApply": true,
+                    "autoApply": false,
                     "opens": $element.offset().left < 500? "right": "left",
                     "id": layout.qInfo.qId
                 };
@@ -160,12 +164,21 @@ define(["qlik", "jquery", "./lib/moment.min", "./CalendarSettings", "css!./css/s
                 if (layout.props.CustomRangesEnabled) {
                     config.locale.customRangeLabel = layout.props.customRangeLabel;
                     config.ranges = rangesLiteral;
-                    rangesLiteral[layout.props.today] = [moment().startOf('day'), moment().startOf('day')];
-                    rangesLiteral[layout.props.yesterday] = [moment().subtract(1, 'days'), moment().subtract(1, 'days')];
-                    rangesLiteral[layout.props.lastXDays.replace("$", "7")] = [moment().subtract(6, 'days'), moment()];
-                    rangesLiteral[layout.props.lastXDays.replace("$", "30")] = [moment().subtract(29, 'days'), moment()];
-                    rangesLiteral[layout.props.thisMonth] = [moment().startOf('month'), moment().endOf('month')];
-                    rangesLiteral[layout.props.lastMonth] = [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')];
+                    if(layout.props.enableToday) rangesLiteral[layout.props.today] = [moment().startOf('day'), moment().startOf('day')];
+                    if(layout.props.enableYesterday) rangesLiteral[layout.props.yesterday] = [moment().subtract(1, 'days'), moment().subtract(1, 'days')];
+                    // if(layout.props.enableToday) rangesLiteral[layout.props.lastXDays.replace("$", "7")] = [moment().subtract(6, 'days'), moment()];
+                    if(layout.props.enableLastXDays) rangesLiteral[layout.props.lastXDays.replace("$", "30")] = [moment().subtract(29, 'days'), moment()];
+                    if(layout.props.enableThisMonth) rangesLiteral[layout.props.thisMonth] = [moment().startOf('month'), moment().endOf('month')];
+                    if(layout.props.enableLastMonth) rangesLiteral[layout.props.lastMonth] = [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')];
+                    
+                    if(layout.props.enableCurrentQuarter) rangesLiteral[layout.props.currentQuarter] = [moment().startOf('quarter'), moment().endOf('quarter')];
+                    if(layout.props.enableLastQuarter) rangesLiteral[layout.props.lastQuarter] = [moment().startOf('quarter').subtract(1, 'quarter'), moment().startOf('quarter').subtract(1, 'day')];
+                    if(layout.props.enableCurrentYear) rangesLiteral[layout.props.currentYear] = [moment().startOf('year'), moment().endOf('year')];                    
+                    if(layout.props.enableLastYear) rangesLiteral[layout.props.lastYear] = [moment().startOf('year').subtract(1, 'years'), moment().startOf('year').subtract(1, 'days')];
+                    if(layout.props.enableQuarterToDate) rangesLiteral[layout.props.quarterToDate] = [moment().startOf('quarter'), moment()];
+                    if(layout.props.enableYearToDate) rangesLiteral[layout.props.yearToDate] = [moment().startOf('year'), moment()];
+                    if(layout.props.enableRolling12Months) rangesLiteral[layout.props.rolling12Months] = [moment().subtract(12, 'months'), moment()];
+                    if(layout.props.enableRolling12MonthsFull) rangesLiteral[layout.props.rolling12MonthsFull] = [moment().subtract(12, 'months').startOf('month'), moment().startOf('month').subtract(1, 'days')];
                 }
 
                 $('#' + dateRangeId).daterangepicker(config,
@@ -211,9 +224,12 @@ define(["qlik", "jquery", "./lib/moment.min", "./CalendarSettings", "css!./css/s
                                 rows = dataPages[0].qMatrix.length;
 
                             UpdateText(start, end);
-
-                            if (rows !== end.diff(start, 'days') + 1) {
-                                $('#' + dateRangeId + ' span').html($('#' + dateRangeId + ' span').html() + ' [' + rows + ' / ' + (end.diff(start, 'days') + 1) + ']')
+                            
+                            // show records vs dates available in calendar dropdown text 
+                            if(layout.props.isSelectionDetailsEnabled) {
+                                if (rows !== end.diff(start, 'days') + 1) {
+                                    $('#' + dateRangeId + ' span').html($('#' + dateRangeId + ' span').html() + ' [' + rows + ' / ' + (end.diff(start, 'days') + 1) + ']')
+                                }
                             }
                         });
                     }

--- a/lib/daterangepicker.css
+++ b/lib/daterangepicker.css
@@ -202,6 +202,14 @@ changed left and right rule names to prevent clash with sense client css */
       background: #08c;
       border: 1px solid #08c;
       color: #fff; }
+  .ranges li.disableRange {
+    background: #f5f5f5;
+    color: #999; }
+    .ranges li.disableRange:hover {
+      background: #f5f5f5;
+      border: 1px solid #f5f5f5;
+      color: #999;
+      cursor: not-allowed }
 
 /*  Larger Screen Styling */
 @media (min-width: 564px) {

--- a/lib/daterangepicker.js
+++ b/lib/daterangepicker.js
@@ -100,13 +100,14 @@
         //allow setting options with data attributes
         //data-api options will be overwritten with custom javascript options
         options = $.extend(this.element.data(), options);
-
+        
         //html template for the picker UI
+        var disableDateInputFields =  options.disableDateInputFields ? "disabled" : "";
         if (typeof options.template !== 'string')
             options.template = '<div id= "dropDown_' + options.id + '" div class="bootstrap_inside daterangepicker dropdown-menu" style="display:none">' +
                 '<div class="calendar dpleft">' +
                     '<div class="daterangepicker_input">' +
-                      '<input class="input-mini" type="text" name="daterangepicker_start" value="" />' +
+                      '<input class="input-mini" type="text" name="daterangepicker_start" ' + disableDateInputFields + ' value="" />' +
                       '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
                       '<div class="calendar-time">' +
                         '<div></div>' +
@@ -117,7 +118,7 @@
                 '</div>' +
                 '<div class="calendar dpright">' +
                     '<div class="daterangepicker_input">' +
-                      '<input class="input-mini" type="text" name="daterangepicker_end" value="" />' +
+                      '<input class="input-mini" type="text" name="daterangepicker_end" ' + disableDateInputFields + ' value="" />' +
                       '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
                       '<div class="calendar-time">' +
                         '<div></div>' +
@@ -296,6 +297,8 @@
         }
 
         if (typeof options.ranges === 'object') {
+            
+            var rangeButtonList = '<ul>';
             for (range in options.ranges) {
 
                 if (typeof options.ranges[range][0] === 'string')
@@ -321,24 +324,29 @@
 
                 // If the end of the range is before the minimum or the start of the range is
                 // after the maximum, don't display this range option at all.
-                if ((this.minDate && end.isBefore(this.minDate)) || (maxDate && start.isAfter(maxDate)))
-                    continue;
+                var disableRange = 'class="enableRange"';
+                if((this.minDate && end.isBefore(this.minDate)) || (maxDate && start.isAfter(maxDate))) {
+                    if(options.rangeOptions.showInvalidRanges)
+                        disableRange = 'class="disableRange" title="There is no data available for this range"';
+                    else
+                        continue;
+                }
                 
                 //Support unicode chars in the range names.
                 var elem = document.createElement('textarea');
                 elem.innerHTML = range;
                 var rangeHtml = elem.value;
 
+                // TODO: is it used somewhere else?
                 this.ranges[rangeHtml] = [start, end];
+
+                // Add range button to list
+                rangeButtonList += '<li ' + disableRange + '>' + rangeHtml + '</li>';
             }
 
-            var list = '<ul>';
-            for (range in this.ranges) {
-                list += '<li>' + range + '</li>';
-            }
-            list += '<li>' + this.locale.customRangeLabel + '</li>';
-            list += '</ul>';
-            this.container.find('.ranges').prepend(list);
+            rangeButtonList += '<li class="enableRange">' + this.locale.customRangeLabel + '</li>';
+            rangeButtonList += '</ul>';
+            this.container.find('.ranges').prepend(rangeButtonList);
         }
 
         if (typeof cb === 'function') {
@@ -415,9 +423,9 @@
         this.container.find('.ranges')
             .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
             .on('click.daterangepicker', 'button.cancelBtn', $.proxy(this.clickCancel, this))
-            .on('click.daterangepicker', 'li', $.proxy(this.clickRange, this))
-            .on('mouseenter.daterangepicker', 'li', $.proxy(this.hoverRange, this))
-            .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
+            .on('click.daterangepicker', 'li.enableRange', $.proxy(this.clickRange, this))
+            .on('mouseenter.daterangepicker', 'li.enableRange', $.proxy(this.hoverRange, this))
+            .on('mouseleave.daterangepicker', 'li.enableRange', $.proxy(this.updateFormInputs, this));
 
         if (this.element.is('input')) {
             this.element.on({


### PR DESCRIPTION
Total Changes Are here:

- Added enable/disable for ranges (Calendar settings, lib/datepicker.css, lib/datepicker.js)
- Added Ranges: Current & Last quarters, Current & Last years, Year to date, quarter to date, rolling 12 months, rolling 12 months full
- Added Miscellaneous section in calendar options
    - Show selection details (eg: 2/32)
    - Disable date input text boxes
    - Show and grey invalid date ranges (for UX Consistency)
![dateranges in properties](https://user-images.githubusercontent.com/3024982/44615121-6c709380-a84f-11e8-839b-851eb00c0d82.PNG)
![properties panel](https://user-images.githubusercontent.com/3024982/44615122-6c709380-a84f-11e8-9284-26915b4c8c11.PNG)
![calendar](https://user-images.githubusercontent.com/3024982/44615172-08e76580-a851-11e8-9038-bfd9cc3e67f7.PNG)
